### PR TITLE
Added m2m_changed signal

### DIFF
--- a/django_typesense/signals.py
+++ b/django_typesense/signals.py
@@ -1,4 +1,4 @@
-from django.db.models.signals import post_save, pre_delete
+from django.db.models.signals import m2m_changed, post_save, pre_delete
 from django.dispatch import receiver
 
 from django_typesense.mixins import TypesenseModelMixin
@@ -18,3 +18,20 @@ def pre_delete_typesense_models(sender, instance, **kwargs):
         return
 
     sender.get_collection(instance).delete()
+
+
+@receiver(m2m_changed)
+def m2m_changed_typesense_models(instance, model, action, reverse, **kwargs):
+    if not isinstance(instance, TypesenseModelMixin) and not issubclass(
+        model, TypesenseModelMixin
+    ):
+        return  # pragma: no cover
+
+    if action in ["post_add", "post_remove", "post_clear"]:
+        if reverse:
+            pk_set = list(kwargs.get("pk_set"))
+            obj = model.objects.filter(pk__in=pk_set)
+            model.get_collection(obj=obj, many=True).update()
+        else:
+            instance_class = instance.__class__
+            instance_class.get_collection(instance).update()

--- a/tests/test_typesense_model_mixin.py
+++ b/tests/test_typesense_model_mixin.py
@@ -1,12 +1,11 @@
 from datetime import date, timedelta
 
 from django.test import TestCase
-from typesense import exceptions
 
-from django_typesense.typesense_client import client
 from django_typesense.mixins import TypesenseManager
 
 from tests.models import Artist, Genre, Song
+from tests.utils import get_document
 
 
 class TestTypeSenseMixin(TestCase):
@@ -22,12 +21,6 @@ class TestTypeSenseMixin(TestCase):
         )
         self.song.artists.add(self.artist.pk)
 
-    def get_document(self, schema_name, document_id):
-        try:
-            return client.collections[schema_name].documents[document_id].retrieve()
-        except exceptions.ObjectNotFound:
-            return None
-
     def test_get_collection_class(self):
         collection_class = Song.get_collection_class()
         self.assertEqual(collection_class.__name__, "SongCollection")
@@ -37,28 +30,28 @@ class TestTypeSenseMixin(TestCase):
 
     def test_update_collection(self):
         schema_name = self.song.collection_class.schema_name
-        song_document = self.get_document(schema_name, self.song.pk)
+        song_document = get_document(schema_name, self.song.pk)
         self.assertEqual(song_document["genre_name"], self.song.genre.name)
 
         genre_name = "Dancehall"
         self.genre.name = genre_name
         self.genre.save(update_fields=["name"])
 
-        song_document = self.get_document(schema_name, self.song.pk)
+        song_document = get_document(schema_name, self.song.pk)
         self.assertNotEqual(song_document["genre_name"], self.song.genre.name)
         self.assertEqual(self.song.genre.name, genre_name)
 
         Song.objects.get_queryset().update()
-        song_document = self.get_document(schema_name, self.song.pk)
+        song_document = get_document(schema_name, self.song.pk)
         self.assertEqual(song_document["genre_name"], genre_name)
         self.assertEqual(song_document["genre_name"], self.song.genre.name)
 
     def test_delete_collection(self):
         schema_name = self.song.collection_class.schema_name
-        song_document = self.get_document(schema_name, self.song.pk)
+        song_document = get_document(schema_name, self.song.pk)
         self.assertEqual(song_document["title"], self.song.title)
 
         Song.objects.get_queryset().delete()
 
-        song_document = self.get_document(schema_name, self.song.pk)
+        song_document = get_document(schema_name, self.song.pk)
         self.assertIsNone(song_document)

--- a/tests/test_typesense_signals.py
+++ b/tests/test_typesense_signals.py
@@ -1,0 +1,65 @@
+from datetime import date, timedelta
+
+from django.test import TestCase
+
+from tests.models import Artist, Genre, Song
+from tests.utils import get_document
+
+
+class TestTypeSenseSignals(TestCase):
+    def setUp(self):
+        self.genre = Genre.objects.create(name="genre1")
+        self.artist = Artist.objects.create(name="artist1")
+        self.song = Song.objects.create(
+            title="New Song",
+            genre=self.genre,
+            release_date=date.today(),
+            description="New song description",
+            duration=timedelta(minutes=3, seconds=35),
+        )
+
+    def test_post_save_typesense_models(self):
+        schema_name = self.song.collection_class.schema_name
+        song_document = get_document(schema_name, self.song.pk)
+
+        self.assertIsNotNone(song_document)
+        self.assertEqual(song_document["title"], self.song.title)
+        self.assertEqual(song_document["genre_id"], self.song.genre.pk)
+        self.assertEqual(song_document["genre_name"], self.song.genre.name)
+        self.assertEqual(
+            song_document["release_date"], self.song.release_date_timestamp
+        )
+        self.assertEqual(song_document["number_of_views"], self.song.number_of_views)
+        self.assertEqual(
+            song_document["number_of_comments"], self.song.number_of_comments
+        )
+
+    def test_pre_delete_typesense_models(self):
+        schema_name = self.song.collection_class.schema_name
+        song_pk = self.song.pk
+
+        song_document = get_document(schema_name, song_pk)
+        self.assertIsNotNone(song_document)
+
+        self.genre.delete()
+        self.assertFalse(Song.objects.filter(pk=song_pk).exists())
+        song_document = get_document(schema_name, song_pk)
+        self.assertIsNone(song_document)
+
+    def test_m2m_changed_typesense_models(self):
+        schema_name = self.song.collection_class.schema_name
+
+        song_document = get_document(schema_name, self.song.pk)
+        self.assertIsNotNone(song_document)
+        self.assertCountEqual(song_document["artist_names"], self.song.artist_names())
+
+        self.song.artists.add(self.artist)
+        song_document = get_document(schema_name, self.song.pk)
+        self.assertIsNotNone(song_document)
+        self.assertCountEqual(song_document["artist_names"], self.song.artist_names())
+
+        artist_2 = Artist.objects.create(name="artist2")
+        artist_2.song_set.add(self.song)
+        song_document = get_document(schema_name, self.song.pk)
+        self.assertIsNotNone(song_document)
+        self.assertCountEqual(song_document["artist_names"], self.song.artist_names())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,10 @@
+from typesense import exceptions
+
+from django_typesense.typesense_client import client
+
+
+def get_document(schema_name, document_id):
+    try:
+        return client.collections[schema_name].documents[document_id].retrieve()
+    except exceptions.ObjectNotFound:
+        return None


### PR DESCRIPTION
Resolves #26

## Added `m2m_changed` signal for django_typesense models

### Changes made
- Added `m2m_changed_typesense_models` to handle `ManyToManyField` changes
- Added tests for `django_typesense.signals`
- Added `tests.utils` to contain `get_document`
- Updated `test_typesense_model_mixin` to use new `get_document` from utils