### PR TITLE
41 bug fix/maximum recursion depth exceeded fix

### DIFF
--- a/django_typesense/fields.py
+++ b/django_typesense/fields.py
@@ -7,7 +7,14 @@ from operator import attrgetter
 from django_typesense.utils import get_unix_timestamp
 
 TYPESENSE_SCHEMA_ATTRS = [
-    'name', '_field_type', 'sort', 'index', 'optional', 'facet', 'infix', 'locale'
+    "name",
+    "_field_type",
+    "sort",
+    "index",
+    "optional",
+    "facet",
+    "infix",
+    "locale",
 ]
 
 
@@ -24,7 +31,7 @@ class TypesenseField:
         optional: bool = False,
         facet: bool = False,
         infix: bool = False,
-        locale: str = ''
+        locale: str = "",
     ):
         self._value = value
         self._name = None
@@ -36,7 +43,7 @@ class TypesenseField:
         self.locale = locale
 
     def __str__(self):
-        return f"{self}: {self.name}"
+        return f"{self.name}"
 
     @property
     def field_type(self):
@@ -49,7 +56,7 @@ class TypesenseField:
     @property
     def attrs(self):
         _attrs = {k: getattr(self, k) for k in TYPESENSE_SCHEMA_ATTRS}
-        _attrs['type'] = _attrs.pop('_field_type')
+        _attrs["type"] = _attrs.pop("_field_type")
         return _attrs
 
     def value(self, obj):
@@ -115,6 +122,7 @@ class TypesenseDecimalField(TypesenseField):
     """
     String type is preferred over float
     """
+
     _field_type = "string"
     _sort = True
 
@@ -146,12 +154,7 @@ class TypesenseDateTimeFieldBase(TypesenseField):
 
         _value = get_unix_timestamp(_value)
 
-        try:
-            return int(_value)
-        except (TypeError, ValueError) as e:
-            raise e.__class__(
-                f"Field '{self.name}' expected a number but got {_value}.",
-            ) from e
+        return _value
 
 
 class TypesenseDateField(TypesenseDateTimeFieldBase):
@@ -173,6 +176,7 @@ class TypesenseJSONField(TypesenseField):
     """
     `string` is preferred over `object`
     """
+
     _field_type = "string"
 
     def value(self, obj):
@@ -193,4 +197,8 @@ class TypesenseArrayField(TypesenseField):
         return list(map(self.base_field.to_python, value))
 
 
-TYPESENSE_DATETIME_FIELDS = [TypesenseDateTimeField, TypesenseDateField, TypesenseTimeField]
+TYPESENSE_DATETIME_FIELDS = [
+    TypesenseDateTimeField,
+    TypesenseDateField,
+    TypesenseTimeField,
+]

--- a/django_typesense/fields.py
+++ b/django_typesense/fields.py
@@ -85,7 +85,7 @@ class TypesenseCharField(TypesenseField):
         if isinstance(__value, str):
             return __value
         if __value is None:
-            return ''
+            return ""
         return str(__value)
 
 

--- a/tests/collections.py
+++ b/tests/collections.py
@@ -8,9 +8,7 @@ class SongCollection(TypesenseCollection):
     title = fields.TypesenseCharField()
     genre_name = fields.TypesenseCharField(value="genre.name")
     genre_id = fields.TypesenseSmallIntegerField()
-    release_date = fields.TypesenseDateField(
-        value="release_date_timestamp", optional=True
-    )
+    release_date = fields.TypesenseDateField(optional=True)
     artist_names = fields.TypesenseArrayField(
         base_field=fields.TypesenseCharField(), value="artist_names"
     )

--- a/tests/test_typesense_fields.py
+++ b/tests/test_typesense_fields.py
@@ -47,7 +47,7 @@ class TestTypesenseCharField(TestCase):
         self.assertEqual(title.value(obj=self.song), self.song.title)
 
         optional_field = fields.TypesenseCharField(value="name", optional=True)
-        self.assertIsNone(optional_field.value(obj=self.song))
+        self.assertEqual(optional_field.value(obj=self.song), "")
 
         with self.assertRaises(AttributeError):
             invalid_field = fields.TypesenseCharField(value="invalid_field")

--- a/tests/test_typesense_fields.py
+++ b/tests/test_typesense_fields.py
@@ -1,0 +1,212 @@
+import json
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+
+from django.test import TestCase
+
+from django_typesense import fields
+from tests.collections import SongCollection
+from tests.models import Artist, Genre, Song
+
+
+class TestTypesenseCharField(TestCase):
+    def setUp(self):
+        self.genre = Genre.objects.create(name="genre1")
+        self.song = Song.objects.create(
+            title="New Song",
+            genre=self.genre,
+            release_date=date.today(),
+            description="New song description",
+            duration=timedelta(minutes=3, seconds=35),
+        )
+        self.attrs = [
+            attr if attr != "_field_type" else "type"
+            for attr in fields.TYPESENSE_SCHEMA_ATTRS
+        ]
+
+    def test_string_representation(self):
+        self.assertEqual(str(SongCollection.title), "title")
+
+    def test_attrs(self):
+        title_attrs = SongCollection.title.attrs
+        self.assertCountEqual(title_attrs.keys(), self.attrs)
+        self.assertEqual(title_attrs["name"], "title")
+        self.assertEqual(title_attrs["type"], "string")
+        self.assertEqual(title_attrs["locale"], "")
+        self.assertFalse(title_attrs["sort"])
+        self.assertFalse(title_attrs["optional"])
+        self.assertFalse(title_attrs["facet"])
+        self.assertFalse(title_attrs["infix"])
+        self.assertTrue(title_attrs["index"])
+
+    def test_field_type(self):
+        self.assertEqual(SongCollection.title.field_type, "string")
+
+    def test_value_method(self):
+        title = SongCollection.title
+        self.assertEqual(title.value(obj=self.song), self.song.title)
+
+        optional_field = fields.TypesenseCharField(value="name", optional=True)
+        self.assertIsNone(optional_field.value(obj=self.song))
+
+        with self.assertRaises(AttributeError):
+            invalid_field = fields.TypesenseCharField(value="invalid_field")
+            invalid_field.value(obj=self.song)
+
+    def test_to_python_method(self):
+        title = SongCollection.title.value(obj=self.song)
+        self.assertEqual(SongCollection.title.to_python(value=title), self.song.title)
+
+
+class TestTypesenseIntegerMixin(TestCase):
+    def setUp(self):
+        self.genre = Genre.objects.create(name="genre1")
+        self.song = Song.objects.create(
+            title="New Song",
+            genre=self.genre,
+            release_date=date.today(),
+            description="New song description",
+            duration=timedelta(minutes=3, seconds=35),
+        )
+
+    def test_value_method(self):
+        genre_id = SongCollection.genre_id
+        self.assertEqual(genre_id.value(obj=self.song), self.genre.pk)
+
+        views = fields.TypesenseSmallIntegerField(value="views", optional=True)
+        self.assertIsNone(views.value(obj=self.song))
+
+        self.song.views = "Wrong type"
+        with self.assertRaises(ValueError):
+            views.value(obj=self.song)
+
+
+class TestTypesenseDecimalField(TestCase):
+    def setUp(self):
+        self.genre = Genre.objects.create(name="genre1")
+        self.song = Song.objects.create(
+            title="New Song",
+            genre=self.genre,
+            release_date=date.today(),
+            description="New song description",
+            duration=timedelta(minutes=3, seconds=35),
+        )
+
+    def test_value_method(self):
+        price = fields.TypesenseDecimalField(value="price", optional=True)
+        self.assertEqual(price.value(obj=self.song), "None")
+
+        self.song.price = Decimal("23.00")
+        self.assertEqual(price.value(obj=self.song), "23.00")
+
+    def test_to_python_method(self):
+        price = fields.TypesenseDecimalField(value="price", optional=True)
+        self.song.price = Decimal("23.00")
+        price_value = price.value(obj=self.song)
+        self.assertEqual(price.to_python(value=price_value), Decimal("23.00"))
+
+
+class TestTypesenseDateTimeFieldBase(TestCase):
+    def setUp(self):
+        self.genre = Genre.objects.create(name="genre1")
+        self.song = Song.objects.create(
+            title="New Song",
+            genre=self.genre,
+            release_date=date.today(),
+            description="New song description",
+            duration=timedelta(minutes=3, seconds=35),
+        )
+
+    def test_value_method(self):
+        optional_date = fields.TypesenseDateField(value="optional_field", optional=True)
+        self.assertIsNone(optional_date.value(obj=self.song))
+
+        release_date_timestamp = fields.TypesenseDateField(
+            value="release_date_timestamp"
+        )
+        release_date_timestamp_value = release_date_timestamp.value(obj=self.song)
+        self.assertTrue(isinstance(release_date_timestamp_value, int))
+        self.assertEqual(release_date_timestamp_value, self.song.release_date_timestamp)
+
+    def test_date_field(self):
+        release_date = SongCollection.release_date
+        release_date_value = release_date.value(obj=self.song)
+        self.assertTrue(isinstance(release_date_value, int))
+        self.assertEqual(release_date_value, self.song.release_date_timestamp)
+
+        release_date_to_python = release_date.to_python(value=release_date_value)
+        self.assertTrue(isinstance(release_date_to_python, date))
+        self.assertEqual(release_date_to_python, self.song.release_date)
+
+    def test_time_field(self):
+        release_time = fields.TypesenseTimeField(value="release_time")
+        self.song.release_time = time(hour=13, minute=30, second=0)
+        release_time_value = release_time.value(obj=self.song)
+
+        self.assertTrue(isinstance(release_time.to_python(release_time_value), time))
+        self.assertEqual(
+            release_time.to_python(release_time_value), self.song.release_time
+        )
+
+    def test_datetime_field(self):
+        created_at = fields.TypesenseDateTimeField(value="created_at")
+        self.song.created_at = datetime(
+            year=2023, month=9, day=11, hour=16, minute=20, second=0
+        )
+        created_at_value = created_at.value(obj=self.song)
+
+        self.assertTrue(isinstance(created_at.to_python(created_at_value), datetime))
+        self.assertEqual(
+            created_at.to_python(value=created_at_value), self.song.created_at
+        )
+
+
+class TestTypesenseJSONField(TestCase):
+    def setUp(self):
+        self.genre = Genre.objects.create(name="genre1")
+        self.song = Song.objects.create(
+            title="New Song",
+            genre=self.genre,
+            release_date=date.today(),
+            description="New song description",
+            duration=timedelta(minutes=3, seconds=35),
+        )
+
+    def test_value_method(self):
+        extra_info = fields.TypesenseJSONField(value="extra_info")
+        self.song.extra_info = {"producer": "DJ Something"}
+        extra_info_value = extra_info.value(obj=self.song)
+
+        self.assertTrue(isinstance(extra_info_value, str))
+        self.assertEqual(extra_info_value, json.dumps(self.song.extra_info))
+
+    def test_to_python_method(self):
+        extra_info = fields.TypesenseJSONField(value="extra_info")
+        self.song.extra_info = {"producer": "DJ Something"}
+        extra_info_value = extra_info.value(obj=self.song)
+
+        self.assertEqual(
+            extra_info.to_python(value=extra_info_value), self.song.extra_info
+        )
+
+
+class TestTypesenseArrayField(TestCase):
+    def setUp(self):
+        self.genre = Genre.objects.create(name="genre1")
+        self.artist = Artist.objects.create(name="artist1")
+        self.song = Song.objects.create(
+            title="New Song",
+            genre=self.genre,
+            release_date=date.today(),
+            description="New song description",
+            duration=timedelta(minutes=3, seconds=35),
+        )
+        self.song.artists.add(self.artist)
+
+    def test_to_python_method(self):
+        artist_names = SongCollection.artist_names
+        artist_names_value = artist_names.value(obj=self.song)
+
+        self.assertCountEqual(
+            artist_names.to_python(artist_names_value), self.song.artist_names()
+        )


### PR DESCRIPTION
Resolves #41

### Changes Made
- Added tests for django_typesense fields classes
- Updated `TypesenseField`'s `__str__` method
- Updated `TypesenseDateTimeFieldBase`'s `value` method to remove the try except block
  **Justification**: Given that `get_unix_timestamp` returns only `int` or raises an exception, there is no need for type conversion.
- Formatted the `django_typesense.fields` file