### PR TITLE
define get_search_results to fix autocomplete search errors

### DIFF
--- a/django_typesense/changelist.py
+++ b/django_typesense/changelist.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from django import forms
 from django.contrib import messages
 from django.contrib.admin.exceptions import DisallowedModelAdminToField

--- a/django_typesense/collections.py
+++ b/django_typesense/collections.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import pdb
 from typing import Dict, Iterable, List, Union
 
 from django.db.models import QuerySet


### PR DESCRIPTION
Resolves #67 

## Proposed changes

The AutoCompleteView uses `get_search_results` at some point with uses `get_search_fields`. Because some of the search fields defined are for typesense and not the model, an error occurred when the Django ORM tried to use such fields.
This PR overrides the `get_search_results` method so that it can be used in a typesense safe way.

### Types of changes

What types of changes does your code introduce to DjangoTypesense?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/Siege-Software/django-typesense/blob/main/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
