### PR TITLE
fix keyerror happening when searching non existing fields

### DIFF
--- a/django_typesense/changelist.py
+++ b/django_typesense/changelist.py
@@ -1,3 +1,5 @@
+import logging
+
 from django import forms
 from django.contrib import messages
 from django.contrib.admin.exceptions import DisallowedModelAdminToField
@@ -31,6 +33,8 @@ IGNORED_PARAMS = (
     IS_POPUP_VAR,
     TO_FIELD_VAR,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class ChangeListSearchForm(forms.Form):
@@ -255,7 +259,13 @@ class TypesenseChangeList(ChangeList):
         }
         max_val, min_val, lookup, value = None, None, None, None
 
-        field = self.model.collection_class.get_field(field_name)
+        try:
+            field = self.model.collection_class.get_field(field_name)
+        except KeyError as er:
+            logger.debug(
+                f"Searching `{field_name}` with parameters `{used_parameters}` produced error: {er}"
+            )
+            return search_filters_dict
 
         for key, value in used_parameters.items():
             if not value:


### PR DESCRIPTION
Resolves # (issue)

## Proposed changes

When fields that are not in the collections fields are included in the search parameters, a keyerror was being raised. Solution is to catch the error and return an empty filters dict because the provided one is invalid

### Types of changes

What types of changes does your code introduce to DjangoTypesense?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/Siege-Software/django-typesense/blob/main/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
