### PR TITLE
fix typeerror raised when updating single work

### DIFF
--- a/django_typesense/utils.py
+++ b/django_typesense/utils.py
@@ -41,12 +41,15 @@ def update_batch(documents_queryset: QuerySet, collection_class, batch_no: int) 
     if responses is None:
         return
 
-    failure_responses = [response for response in responses if not response["success"]]
+    if isinstance(responses, list):
+        failure_responses = [
+            response for response in responses if not response["success"]
+        ]
 
-    if failure_responses:
-        raise BatchUpdateError(
-            f"An Error occurred during the bulk update: {failure_responses}"
-        )
+        if failure_responses:
+            raise BatchUpdateError(
+                f"An Error occurred during the bulk update: {failure_responses}"
+            )
 
     logger.debug(f"Batch {batch_no} Updated with {len(collection.data)} records ✓")
 


### PR DESCRIPTION
Resolves # (issue)

## Proposed changes

```
TypeError
string indices must be integers
File "django_typesense/utils.py", line 42, in update_batch
    failure_responses = [response for response in responses if not response["success"]]
  File "django_typesense/utils.py", line 42, in <listcomp>
    failure_responses = [response for response in responses if not response["success"]]
```
An update on a single object returns a dictionary not a list

### Types of changes

What types of changes does your code introduce to DjangoTypesense?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/Siege-Software/django-typesense/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
