### PR TITLE
fix-incorrect-lookup-parameters

### DIFF
--- a/django_typesense/changelist.py
+++ b/django_typesense/changelist.py
@@ -9,8 +9,9 @@ from django.contrib.admin.options import (
     IncorrectLookupParameters,
 )
 from django.contrib.admin.views.main import ChangeList
+from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.core.paginator import InvalidPage
-from django.db.models import OrderBy
+from django.db.models import OrderBy, OuterRef, Exists
 from django.utils.translation import gettext
 from django.utils.dateparse import parse_datetime
 
@@ -408,4 +409,72 @@ class TypesenseChangeList(ChangeList):
     def get_queryset(self, request):
         # this is needed for admin actions that call cl.get_queryset
         # exporting is the currently possible way of getting records from typesense without pagination
-        return super().get_queryset(request)
+        # Typesense team will work on a flag to disable pagination, until then, we need a way to get this to work.
+        # Problem happens when django finds fields only present on typesense in its filter i.e IncorrectLookupParameters
+        # First, we collect all the declared list filters.
+        (
+            self.filter_specs,
+            self.has_filters,
+            remaining_lookup_params,
+            filters_may_have_duplicates,
+            self.has_active_filters,
+        ) = self.get_filters(request)
+        # Then, we let every list filter modify the queryset to its liking.
+        qs = self.root_queryset
+
+        for filter_spec in self.filter_specs:
+            new_qs = filter_spec.queryset(request, qs)
+            if new_qs is not None:
+                qs = new_qs
+
+        lookup_params_keys = remaining_lookup_params.keys()
+        model_field_names = set((local_field.name for local_field in self.model._meta.local_fields))
+        for key in lookup_params_keys:
+            if key not in model_field_names:
+                # means k only available in typesense
+                value = remaining_lookup_params.pop(key)
+                new_lookup_params = self.model.collection_class.get_django_lookup(key, value)
+                remaining_lookup_params.update(new_lookup_params)
+
+        try:
+            # Finally, we apply the remaining lookup parameters from the query
+            # string (i.e. those that haven't already been processed by the
+            # filters).
+            qs = qs.filter(**remaining_lookup_params)
+        except (SuspiciousOperation, ImproperlyConfigured):
+            # Allow certain types of errors to be re-raised as-is so that the
+            # caller can treat them in a special way.
+            raise
+        except Exception as e:
+            # Every other error is caught with a naked except, because we don't
+            # have any other way of validating lookup parameters. They might be
+            # invalid if the keyword arguments are incorrect, or if the values
+            # are not in the correct type, so we might get FieldError,
+            # ValueError, ValidationError, or ?.
+            raise IncorrectLookupParameters(e)
+
+        # Apply search results
+        qs, search_may_have_duplicates = self.model_admin.get_search_results(
+            request,
+            qs,
+            self.query,
+        )
+
+        # Set query string for clearing all filters.
+        self.clear_all_filters_qs = self.get_query_string(
+            new_params=remaining_lookup_params,
+            remove=self.get_filters_params(),
+        )
+        # Remove duplicates from results, if necessary
+        if filters_may_have_duplicates | search_may_have_duplicates:
+            qs = qs.filter(pk=OuterRef("pk"))
+            qs = self.root_queryset.filter(Exists(qs))
+
+        # Set ordering.
+        ordering = self.get_ordering(request, qs)
+        qs = qs.order_by(*ordering)
+
+        if not qs.query.select_related:
+            qs = self.apply_select_related(qs)
+
+        return qs

--- a/django_typesense/collections.py
+++ b/django_typesense/collections.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from operator import methodcaller
 from typing import Dict, Iterable, List, Union
 
 from django.db.models import QuerySet
@@ -195,6 +196,26 @@ class TypesenseCollection(metaclass=TypesenseCollectionMeta):
         """
         fields = cls.get_fields()
         return fields[name]
+
+    @classmethod
+    def get_django_lookup(cls, field, value) -> dict:
+        """
+        Get the lookup that would have been used for this field in django. Expects to find a method on
+        the collection called `get_FIELD_lookup` otherwise a NotImplementedError is raised
+
+        Args:
+            collection_field_name: the name of the field in the collection
+            value: the value to look for
+
+        Returns:
+            A dictionary of the fields to the value.
+        """
+
+        if "get_%s_lookup" % field not in cls.__dict__:
+            raise NotImplementedError
+
+        method = methodcaller("get_%s_lookup" % field, value)
+        return method(cls)
 
     @cached_property
     def schema_fields(self) -> list:


### PR DESCRIPTION
Resolves # (issue)

## Proposed changes

Filters or Lookup params that are custom fields for the typesense collection were causing erroring during queryset filtering because we have to use django. Provide the abilily for provision of custom lookups that can be used for this fields

### Types of changes

What types of changes does your code introduce to DjangoTypesense?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/Siege-Software/django-typesense/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
