### PR TITLE
Update csrf_protect_m import for Django 6.0

### DIFF
--- a/django_typesense/admin.py
+++ b/django_typesense/admin.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.contrib import admin
-from django.contrib.auth.admin import csrf_protect_m
+from django.contrib.admin.options import csrf_protect_m
 from django.db.models import QuerySet
 from django.forms import forms
 from django.http import JsonResponse


### PR DESCRIPTION
## Proposed changes

Django 6.0 removes `contrib.auth.admin.csrf_protect_m`: https://github.com/django/django/pull/18466/files

This PR updates an import of the removed decorator to a still-existing one.

### Types of changes

What types of changes does your code introduce to DjangoTypesense?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Siege-Software/django-typesense/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
  - Current main doesn't pass pre-commit checks
- [ ] I have added tests that prove my fix is effective or that my feature works
  - I can update the test matrix but it seems there are multiple EOL Python / Django versions in it. I'm worried that a simple addition of Django 6.0 won't cut it.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
